### PR TITLE
Added cli switch for configuring stack stage

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -7,27 +7,39 @@ commander
     "-p --currentPath <pathname>",
     "Reference path for examining a serverlesss setup"
   )
+  .option(
+    "-t --stage <stage>",
+    "Stack stage to check against. Defaul value is dev"
+  )
   .option("-f --file-name", "File to write output (default config.json)")
   .option(
     "-s --standard-output",
     "Write to standard output instead of config.json"
   )
-  .action(async ({ currentPath, targetPath, fileName, standardOutput }) => {
-    fileName = fileName && "config.json";
-    targetPath = targetPath && process.cwd();
-    try {
-      const c = await makeConfig({ currentPath });
-      if (standardOutput) {
-        console.log(JSON.stringify(c, null, 2));
-      } else {
-        writeConfig(c, targetPath, fileName);
+  .action(
+    async ({
+      currentPath,
+      targetPath,
+      fileName,
+      standardOutput,
+      stage = "dev"
+    }) => {
+      fileName = fileName && "config.json";
+      targetPath = targetPath && process.cwd();
+      try {
+        const c = await makeConfig({ currentPath, stage });
+        if (standardOutput) {
+          console.log(JSON.stringify(c, null, 2));
+        } else {
+          writeConfig(c, targetPath, fileName);
+        }
+      } catch (e) {
+        console.log(
+          "Caught an error! Is it possible  upstream serverless stacks are not deployed yet?"
+        );
+        console.log("Error message:", e.toString());
+        process.exit(1);
       }
-    } catch (e) {
-      console.log(
-        "Caught an error! Is it possible  upstream serverless stacks are not deployed yet?"
-      );
-      console.log("Error message:", e.toString());
-      process.exit(1);
     }
-  })
+  )
   .parse(process.argv);


### PR DESCRIPTION
This fix setup to tell serverless-resources what type of stack stage should be look up.

Otherwise, serverless-resources always default to looking into a dev cloud formation stack